### PR TITLE
Adding a constraint to the file path max length

### DIFF
--- a/src/node-native/fs.litcoffee
+++ b/src/node-native/fs.litcoffee
@@ -232,7 +232,7 @@ Returns full path to saved file
 twin method: saveAs (legacy)
 
     String::save_As              = (targetFile) ->
-                                      return false if targetFile is null
+                                      return false if targetFile is null or targetFile.length > 255
                                       contents = @.valueOf()
                                       if (targetFile.exists())
                                         targetFile.file_Delete()

--- a/test/node-native/fs.test.coffee
+++ b/test/node-native/fs.test.coffee
@@ -171,6 +171,23 @@ describe '| fs |',->
 
     ''.save_As.assert_Is ''.saveAs
 
+
+  it 'Save_As file path must be 255 characters max', ->
+    file_Name    = '_tmp_file_'.add_Random_String(245)
+    file_Content = ''.add_Random_String(100);
+    file_Name.length                .assert_Is(255);
+    file_Content                    .save_As(file_Name)
+    file_Name.exists()              .assert_Is_True()
+
+  it 'Save_As file path must be 255 characters max (file must not be created)', ->
+    file_Name    = '_tmp_file_'.add_Random_String(1000)
+    file_Content = ''.add_Random_String(100);
+    file_Name.length                .assert_Is(1010);
+    file_Content                    .save_As(file_Name)
+                                    .assert_Is_False()
+
+    file_Name.exists()              .assert_Is_False()
+
   it 'temp_File',->
     value = "abc".add_5_Letters()
     './'.temp_File(value).assert_File_Exists()


### PR DESCRIPTION
Setting up a max path length of 255 characters, which should avoid the Error: ENAMETOOLONG, name too long  error message.
